### PR TITLE
Add to_qp method for BasisSet nodes

### DIFF
--- a/aiida_gaussian_datatypes/basisset/data.py
+++ b/aiida_gaussian_datatypes/basisset/data.py
@@ -523,6 +523,33 @@ class BasisSetCommon(Data):
                         fhandle.write(f"  {ii + 1:3d} {exponent:15.7f} {coefficient:15.7f}\n")
                 offset = num
 
+                
+    def to_qp(self, fhandle):
+        """
+        Write the Basis Set to the passed file handle in the format expected by Quantum Package.
+        (exactly the same as GAMESS format from to_gamess but without the string with UUID of the BasisSet)
+
+        :param fhandle: A valid output file handle
+        """
+        orb_dict = {0 : "s",
+                    1 : "p",
+                    2 : "d",
+                    3 : "f",
+                    4 : "g",
+                    5 : "h",
+                    6 : "i" }
+
+        for block in self.blocks:
+            offset = 0
+            for orb, num, in block["l"]:
+                fhandle.write(f" {orb_dict[orb].upper()}  {len(block['coefficients'])}\n")
+                for lnum in range(num):
+                    for ii, entry in enumerate(block["coefficients"]):
+                        exponent = entry[0]
+                        coefficient = entry[1 + lnum + offset]
+                        fhandle.write(f"  {ii + 1:3d} {exponent:15.7f} {coefficient:15.7f}\n")
+                offset = num
+
 
     def get_matching_pseudopotential(self, *args, **kwargs):
         """


### PR DESCRIPTION
The `.to_qp` method is useful to print basis sets in the format recognizable by Quantum Package. `.to_gamess` prints one line with `uuid` as a comment, which prevents QP from parsing the file.